### PR TITLE
.yaml -> .yml

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -1,5 +1,5 @@
 # === copier settings ===
-_answers_file: .copier-answers.yaml
+_answers_file: .copier-answers.yml
 _min_copier_version: '9.4.1'
 _subdirectory: template
 _skip_if_exists:


### PR DESCRIPTION
Not sure why it doesn't understand the `.yaml` file extension in the child projects, but here we are (maybe something to raise an issue for on the copier repo?)