### PR TITLE
Fix dirty copier status during version check

### DIFF
--- a/.github/workflows/template-check-version.yml
+++ b/.github/workflows/template-check-version.yml
@@ -29,9 +29,9 @@ jobs:
         run: |
           pixi add copier
           pixi install
-          git stash
+          git stash push -m pixi.lock -m pixi.toml
 
-      - name: Add dummy GitHub credentials.
+      - name: Add dummy GitHub credentials
         run: |
           git config --global user.name Copier update
           git config --global user.email check@dummy.bot.com

--- a/.github/workflows/template-check-version.yml
+++ b/.github/workflows/template-check-version.yml
@@ -29,8 +29,7 @@ jobs:
         run: |
           pixi add copier
           pixi install
-          git stash push -m pixi.lock -m pixi.toml
-
+          git stash push -m "Stash pixi lock and toml" -- pixi.lock pixi.toml
       - name: Add dummy GitHub credentials
         run: |
           git config --global user.name Copier update

--- a/.github/workflows/template-check-version.yml
+++ b/.github/workflows/template-check-version.yml
@@ -25,10 +25,13 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.8.3
 
-      - name: Add copier
-        run: pixi add copier
+      - name: Add copier, install it, and stash to avoid 'dirty' copier warnings
+        run: |
+          pixi add copier
+          pixi install
+          git stash
 
-      - name: Add dummy GitHub credentials
+      - name: Add dummy GitHub credentials.
         run: |
           git config --global user.name Copier update
           git config --global user.email check@dummy.bot.com


### PR DESCRIPTION
Fixes #15

After pixi installs copier, we stash changes to ensure the modified lockfile does not impact the check.