### PR TITLE
Remove escape characters from the update message.

### DIFF
--- a/.github/workflows/template-check-version.yml
+++ b/.github/workflows/template-check-version.yml
@@ -45,6 +45,6 @@ jobs:
         run: |
           gh issue --repo ${{ github.repository }} \
           create --title "Template update" \
-          --body "The template has been updated.\n\nPlease run \`copier update\` in your local copy, review the changes, and merge them into the repository.\n\nIf you need help, refer to the \`clio\` documentation or reach out to the calliope project team."
+          --body "A new version of the template has been published. Please update this project using \`copier update --skip-answered --defaults\` and review changes. If you need help, refer to the \`clio\` documentation or reach out to the calliope project team."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Seems like `\n` is not valid for git messages. I've removed them and added a few syntax improvements to the update message.
