### PR TITLE
Skip example enterely to minimise false positives in template updates

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -13,7 +13,7 @@ _exclude:
     - ".svn"
     # Do not add the dummy example when updating
     - "{% if _copier_operation == 'update' -%}workflow/envs/shell.yaml{% endif %}"
-    - "{% if _copier_operation == 'update' -%}workflow/internal/config.shema.yaml{% endif %}"
+    - "{% if _copier_operation == 'update' -%}workflow/internal/config.schema.yaml{% endif %}"
     - "{% if _copier_operation == 'update' -%}workflow/internal/settings.yaml{% endif %}"
     - "{% if _copier_operation == 'update' -%}workflow/rules/automatic.smk{% endif %}"
     - "{% if _copier_operation == 'update' -%}workflow/rules/dummy.smk{% endif %}"


### PR DESCRIPTION
The previous version of the template does not skip example configuration / schema and similar files.

This can lead to false positives or risk changes to them 'trickling' down to projects.
To avoid this, we generate them once during `copy`, and skip them entirely in following updates since they'll be project-exclusive.

If a project removes an essential file (like the schema) or brakes naming convention, this should be identified in parsing projects like `clio`, not by the template.

The one file I left was `Snakefile`, to enable us to update things like the minimal compatible version in case of breaking changes on snakemake.