### PR TITLE
Do not switch to 'latest' in template check (check against 'main')

### DIFF
--- a/.github/workflows/template-check-version.yml
+++ b/.github/workflows/template-check-version.yml
@@ -19,8 +19,6 @@ jobs:
       UPDATE: "false"
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: "latest"  # This avoids comparing against development versions.
 
       - uses: mamba-org/setup-micromamba@v2
         with:


### PR DESCRIPTION
Switching to 'latest' in the scheduled test induces false positives.
