### PR TITLE
Fix template check + minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ We require [`pixi`](https://pixi.sh/) as a package manager. Once installed, do t
    copier copy https://github.com/modelblocks-org/data-module-template.git ./<module_name>
    ```
 
-   > [!TIP]
-   > If your terminal does not have access to `copier` then you may need to update your `PATH` variable to include `~/.pixi/bin`.
+> [!TIP]
+> If your terminal does not have access to `copier` then you may need to update your `PATH` variable to include `~/.pixi/bin`.
 
 3. Answer some questions so can we pre-fill licensing, citation files, etc...
 4. Initialise the `pixi` project environment of your new module.

--- a/template/.github/workflows/check-version.yml
+++ b/template/.github/workflows/check-version.yml
@@ -1,9 +1,13 @@
 # Check for changes in the upstream template. If changes are found, an issue is created
 name: Template check.
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 1 * *' # Runs at 00:00 UTC on the 1st day of every month
 
 jobs:
   copier-update:
+    permissions:
+      contents: read
+      issues: write
     uses: modelblocks-org/data-module-template/.github/workflows/template-check-version.yml@latest

--- a/template/.github/workflows/pr-ci.yml
+++ b/template/.github/workflows/pr-ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-logs-${{ matrix.os }}
-          path: tests/integration/results/integration_test/logs
+          path: tests/integration/resources/module/logs
           if-no-files-found: ignore
           retention-days: 30
       - name: Fail if integration or linting failed

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -18,6 +18,7 @@ and the `snakemake` [documentation](https://snakemake.readthedocs.io/en/stable/s
 <!-- Please describe the processing stages of this module here -->
 
 Data processing steps:
+
 1.
 2.
 

--- a/template/pixi.toml.jinja
+++ b/template/pixi.toml.jinja
@@ -19,7 +19,7 @@ pytest = ">=8.3.5"
 python = ">=3.12"
 ruff = ">=0.9.9"
 snakefmt = ">=0.10.2"
-snakemake-minimal = ">=8.29.0"
+snakemake-minimal = ">=9.19.0"
 pytz = ">=2026.1.post1"
 
 [tasks]

--- a/template/tests/integration/{% if true %}Snakefile{% endif %}.jinja
+++ b/template/tests/integration/{% if true %}Snakefile{% endif %}.jinja
@@ -30,9 +30,9 @@ module {{module_short_name}}:
         # Redirect specific module results (outputs)
         combined_text="results/output/combined_text.md",
         # Redirect intermediate files that are internal to the module
-        logs="resources/{{module_short_name}}/logs",
-        resources="resources/{{module_short_name}}/resources",
-        results="resources/{{module_short_name}}/results"
+        logs="resources/module/logs",
+        resources="resources/module/resources",
+        results="resources/module/results"
 
 
 # rename all module rules with a prefix, to avoid naming conflicts.

--- a/template/workflow/Snakefile
+++ b/template/workflow/Snakefile
@@ -2,7 +2,7 @@ import yaml
 
 from snakemake.utils import min_version, validate
 
-min_version("8.10")
+min_version("9.19")
 
 
 # !!!!! IMPORTANT !!!!!
@@ -43,7 +43,7 @@ rule all:
     output:
         "INVALID",
     log:
-        stderr="logs/all.stderr",
+        stderr="<logs>/all.stderr",
     conda:
         "envs/shell.yaml"
     shell:


### PR DESCRIPTION
Updates the scheduled template check:
- Adds "write" permissions so the issue can be created (Github is now pickier in this regard).
- Adds an option to run the workflow manually.

Additionally, fixes:
- #48 
- #47 
- #49 
- #51
